### PR TITLE
Fix baseUrl handling

### DIFF
--- a/tmtc-c2a/build.rs
+++ b/tmtc-c2a/build.rs
@@ -9,11 +9,6 @@ fn main() {
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
 
     if std::env::var("SKIP_FRONTEND_BUILD").is_err() {
-        let mut env_vars: Vec<(&str, &str)> = vec![];
-        #[cfg(feature = "prefer_self_port")]
-        {
-            env_vars.push(("VITE_PREFER_SELF_PORT", "1"));
-        }
         let status = Command::new("yarn")
             .current_dir("devtools_frontend")
             .status()
@@ -22,7 +17,6 @@ fn main() {
         let status = Command::new("yarn")
             .current_dir("devtools_frontend")
             .arg("build")
-            .envs(env_vars)
             .status()
             .expect("failed to build frontend");
         assert!(status.success());

--- a/tmtc-c2a/devtools_frontend/src/components/Layout.tsx
+++ b/tmtc-c2a/devtools_frontend/src/components/Layout.tsx
@@ -24,12 +24,10 @@ const formatU8Hex = (u8: number) => {
 };
 
 type TelemetryListSidebarProps = {
-  baseUrl: string;
   activeName: string | undefined;
   telemetryListItems: TelemetryMenuItem[];
 };
 const TelemetryListSidebar: React.FC<TelemetryListSidebarProps> = ({
-  baseUrl,
   activeName: tmivName,
   telemetryListItems,
 }) => {
@@ -38,7 +36,7 @@ const TelemetryListSidebar: React.FC<TelemetryListSidebarProps> = ({
       <ul>
         <li>
           <NavLink
-            to={`/${baseUrl}/command`}
+            to={`/command`}
             className={({ isActive }) =>
               `${Classes.MENU_ITEM} ${isActive ? Classes.ACTIVE : ""}`
             }
@@ -62,7 +60,7 @@ const TelemetryListSidebar: React.FC<TelemetryListSidebarProps> = ({
           return (
             <li key={item.name}>
               <Link
-                to={`/${baseUrl}/telemetries/${item.name}`}
+                to={`/telemetries/${item.name}`}
                 className={`${Classes.MENU_ITEM} ${
                   tmivName === item.name ? Classes.ACTIVE : ""
                 }`}
@@ -87,7 +85,6 @@ const TelemetryListSidebar: React.FC<TelemetryListSidebarProps> = ({
 export const Layout = () => {
   const ctx = useLoaderData() as ClientContext;
   const params = useParams();
-  const baseUrl = params["baseUrl"]!;
   const tmivName = params["tmivName"];
 
   const telemetryListItems = useMemo(() => {
@@ -141,7 +138,6 @@ export const Layout = () => {
             collapsible
           >
             <TelemetryListSidebar
-              baseUrl={baseUrl}
               activeName={tmivName}
               telemetryListItems={telemetryListItems}
             />

--- a/tmtc-c2a/devtools_frontend/src/components/Layout.tsx
+++ b/tmtc-c2a/devtools_frontend/src/components/Layout.tsx
@@ -133,8 +133,8 @@ export const Layout = () => {
         <PanelGroup direction="horizontal" autoSaveId="c2a-devtools">
           <Panel
             className="bg-slate-900 text-slate-200 flex flex-col shrink-0 grow-0 h-full"
-            minSize={2}
-            defaultSize={20}
+            minSizePixels={2}
+            defaultSizePercentage={20}
             collapsible
           >
             <TelemetryListSidebar


### PR DESCRIPTION
#33 で、フロントエンドを `/devtools/` 以下でサーブするようにしてもらったので、それに合わせてフロントエンドを修正しました。
かつては、パスの最初のセグメントに接続先のホスト・ポートを入れられる仕様でしたが、tmtc-c2a と統合されたあとではその機能は不要なため、削除しています。
