### PR TITLE
Devtoolsのprotocコード生成ルールを修正

### DIFF
--- a/tmtc-c2a/devtools_frontend/package.json
+++ b/tmtc-c2a/devtools_frontend/package.json
@@ -2,9 +2,9 @@
   "name": "c2a-devtools",
   "version": "0.0.0",
   "scripts": {
-    "codegen:proto:tco_tmiv": "protoc --ts_out src/proto --proto_path ../gaia/gaia-stub/proto ../gaia/gaia-stub/proto/tco_tmiv.proto",
-    "codegen:proto:broker": "protoc --ts_out src/proto --proto_path ../gaia/gaia-stub/proto ../gaia/gaia-stub/proto/broker.proto",
-    "codegen:proto:tmtc_generic_c2a": "protoc --ts_out src/proto --proto_path ../gaia/tmtc-c2a/proto ../gaia/tmtc-c2a/proto/tmtc_generic_c2a.proto",
+    "codegen:proto:tco_tmiv": "protoc --ts_out src/proto --proto_path ../../gaia-stub/proto ../../gaia-stub/proto/tco_tmiv.proto",
+    "codegen:proto:broker": "protoc --ts_out src/proto --proto_path ../../gaia-stub/proto ../../gaia-stub/proto/broker.proto",
+    "codegen:proto:tmtc_generic_c2a": "protoc --ts_out src/proto --proto_path ../../tmtc-c2a/proto ../../tmtc-c2a/proto/tmtc_generic_c2a.proto",
     "codegen:proto": "run-p codegen:proto:*",
     "codegen": "run-s codegen:proto",
     "dev:vite": "vite --host",


### PR DESCRIPTION
.protoファイルへの相対パスが正しくなくなっていた