### PR TITLE
Embed C2A DevTools into tmtc-c2a binary on debug build

### DIFF
--- a/tmtc-c2a/Cargo.toml
+++ b/tmtc-c2a/Cargo.toml
@@ -28,7 +28,7 @@ tonic-health = "0.10"
 tonic-reflection = "0.10"
 tonic-web = "0.10"
 axum = { version = "0.6", default-features = false, features = ["http1", "tokio"] }
-rust-embed = { version = "8.0.0", features = ["interpolate-folder-path"] }
+rust-embed = { version = "8.0.0", features = ["interpolate-folder-path", "debug-embed"] }
 mime_guess = "2.0.4"
 sentry = { version = "0.31", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest"] }
 sentry-tracing = "0.31"


### PR DESCRIPTION
[rust-embed](https://github.com/pyrossh/rust-embed) はデフォルト挙動では debug build 時に embed せず，実行場所からの相対パスのディレクトリを読み込む（そうか？）．
> In `debug` and when `debug-embed` feature is not enabled, the folder path is resolved relative to where the binary is run from.

しかし，#33 の目的は単に commit された静的アセットの埋め込みを行いたいわけではなく，ビルド済みの C2A DevTools フロントエンドのコードをバイナリに埋め込こみ，C2A Boom ツールチェーンの配布をシンプルにするためであり，C2A DevTools は基本的に常に埋め込みを行いたい．

そのため，`rust-embed` crate の `debug-embed` feature を有効化する．

## 備考
実行時に読み込みを行いたいユースケースとしては真に C2A DevTools の開発時などが考えられるが，Gaia の開発時 != C2A DevTools の開発時（包含関係ではあるが，常にではない）．埋め込みを行わない場合は C2A DevTools のビルドを別途行わないとフルの動作確認ができないため，C2A DevTools 以外の Gaia の開発時にも実行時に読み込みが走る挙動は非自明かつ冗長となる．

また，現在は（まだバイナリ配布を整備していないこともあり）ビルド速度などのために `cargo install --debug` している箇所が多く，事実上 debug build であっても Gaia の開発が行われているわけではない．