### PR TITLE
Build C2A DevTools in OUT_DIR

### DIFF
--- a/tmtc-c2a/build.rs
+++ b/tmtc-c2a/build.rs
@@ -17,7 +17,7 @@ fn main() {
 
         // copy frontend source into OUT_DIR
         let devtools_build_dir = out_dir.join("devtools_frontend");
-        copy_dir_all("devtools_frontend", &devtools_build_dir).unwrap();
+        copy_devtools_dir("devtools_frontend", &devtools_build_dir).unwrap();
 
         let status = Command::new("yarn")
             .current_dir(&devtools_build_dir)
@@ -39,13 +39,16 @@ fn main() {
     }
 }
 
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+fn copy_devtools_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     fs::create_dir_all(&dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
         if ty.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            if entry.file_name().to_str() == Some("node_modules") {
+                continue;
+            }
+            copy_devtools_dir(entry.path(), dst.as_ref().join(entry.file_name()))?;
         } else {
             fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
         }

--- a/tmtc-c2a/build.rs
+++ b/tmtc-c2a/build.rs
@@ -1,8 +1,12 @@
 use std::process::Command;
-use std::{env, path::PathBuf};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+};
 
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
     tonic_build::configure()
         .file_descriptor_set_path(out_dir.join("tmtc_generic_c2a.bin"))
         .compile(&["./proto/tmtc_generic_c2a.proto"], &["./proto"])
@@ -10,14 +14,20 @@ fn main() {
 
     if std::env::var("SKIP_FRONTEND_BUILD").is_err() {
         println!("cargo:rerun-if-changed=devtools_frontend");
+
+        // copy frontend source into OUT_DIR
+        let devtools_build_dir = out_dir.join("devtools_frontend");
+        copy_dir_all("devtools_frontend", &devtools_build_dir).unwrap();
+
         let status = Command::new("yarn")
-            .current_dir("devtools_frontend")
+            .current_dir(&devtools_build_dir)
             .status()
             .expect("failed to build frontend");
         assert!(status.success());
+
         let devtools_out_dir = out_dir.join("devtools_dist");
         let status = Command::new("yarn")
-            .current_dir("devtools_frontend")
+            .current_dir(&devtools_build_dir)
             .arg("run")
             .arg("build:vite")
             .arg("--")
@@ -27,4 +37,18 @@ fn main() {
             .expect("failed to build frontend");
         assert!(status.success());
     }
+}
+
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
 }

--- a/tmtc-c2a/build.rs
+++ b/tmtc-c2a/build.rs
@@ -22,8 +22,8 @@ fn main() {
         let status = Command::new("yarn")
             .current_dir(&devtools_build_dir)
             .status()
-            .expect("failed to build frontend");
-        assert!(status.success());
+            .expect("failed to execute yarn");
+        assert!(status.success(), "failed to install deps for frontend");
 
         let devtools_out_dir = out_dir.join("devtools_dist");
         let status = Command::new("yarn")
@@ -34,8 +34,8 @@ fn main() {
             .arg("--outDir")
             .arg(&devtools_out_dir)
             .status()
-            .expect("failed to build frontend");
-        assert!(status.success());
+            .expect("failed to execute yarn");
+        assert!(status.success(), "failed to build frontend");
     }
 }
 


### PR DESCRIPTION
- 現状では，`yarn build` がビルドスクリプトの動作ディレクトリで行われている
- これは基本的にソースファイルのあるディレクトリ
  - つまり，開発時のディレクトリや，`~/.cargo/git/checkouts/` 以下など
- これではソースディレクトリがソースファイル以外の状態を持ってしまう
- 開発時のディレクトリで `yarn build` が行われる分には一見あまり影響は無いように思えるが，`~/.cargo/git/checkouts/` 以下などが状態を持つと，リリースしたはずの crate のビルドがべき等ではなくなってしまう
- 具体的には， #60 の前後では前回のビルド時の `node_modules` が `$OUT_DIR/devtools_frontend` にコピーされ，一つ目の `yarn` がコケることがある
- そこで，`devtools_frontend` ディレクトリを `$OUT_DIR` にコピーしてから `yarn`, `yarn build` を行うように変更する