### PR TITLE
Fix internal crate ref version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,7 @@ dependencies = [
  "funty",
  "modular-bitfield-msb",
  "serde",
- "structpack 0.5.0",
+ "structpack 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tlmcmddb",
  "zerocopy",
 ]
@@ -1810,9 +1810,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structpack"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e857273e9c89100a44850de8c57bce6bb44e83095345dc9e604429036e7f40"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -1823,6 +1821,8 @@ dependencies = [
 [[package]]
 name = "structpack"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177c21a9780e03494720b18999dc6a5fa0b553c51d59d33cff7f086e37631c7e"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2005,7 +2005,7 @@ dependencies = [
  "sentry-tracing",
  "serde",
  "serde_json",
- "structpack 0.5.0",
+ "structpack 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tlmcmddb",
  "tokio",
  "tokio-tungstenite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-ccsds-c2a"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -599,14 +599,14 @@ dependencies = [
  "funty",
  "modular-bitfield-msb",
  "serde",
- "structpack 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structpack 0.6.0",
  "tlmcmddb",
  "zerocopy",
 ]
 
 [[package]]
 name = "gaia-stub"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "prost",
  "prost-types",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-tmtc"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1811,6 +1811,8 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "structpack"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177c21a9780e03494720b18999dc6a5fa0b553c51d59d33cff7f086e37631c7e"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -1820,9 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "structpack"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177c21a9780e03494720b18999dc6a5fa0b553c51d59d33cff7f086e37631c7e"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "tmtc-c2a"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2005,7 +2005,7 @@ dependencies = [
  "sentry-tracing",
  "serde",
  "serde_json",
- "structpack 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structpack 0.6.0",
  "tlmcmddb",
  "tokio",
  "tokio-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 
 [workspace.dependencies]
 structpack = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,10 @@ members = [
 
 [workspace.package]
 version = "0.6.0"
+
+[workspace.dependencies]
+structpack = "0.5.0"
+
+gaia-stub = { path = "gaia-stub" }
+gaia-ccsds-c2a = { path = "gaia-ccsds-c2a" }
+gaia-tmtc = { path = "gaia-tmtc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 version = "0.6.0"
 
 [workspace.dependencies]
-structpack = "0.5.0"
+structpack = "0.6"
 
 gaia-stub = { path = "gaia-stub" }
 gaia-ccsds-c2a = { path = "gaia-ccsds-c2a" }

--- a/gaia-ccsds-c2a/Cargo.toml
+++ b/gaia-ccsds-c2a/Cargo.toml
@@ -15,5 +15,5 @@ modular-bitfield-msb = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 zerocopy = "0.6"
 tlmcmddb = "0.2.0"
-structpack = "0.5.0"
+structpack.workspace = true
 async-trait = "0.1"

--- a/gaia-tmtc/Cargo.toml
+++ b/gaia-tmtc/Cargo.toml
@@ -16,5 +16,5 @@ tokio = { version = "1", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = "0.10"
 prost-types = "0.12"
-gaia-stub = { path = "../gaia-stub" }
+gaia-stub.workspace = true
 serde = { version = "1", features = ["derive"] }

--- a/tmtc-c2a/Cargo.toml
+++ b/tmtc-c2a/Cargo.toml
@@ -33,9 +33,9 @@ mime_guess = "2.0.4"
 sentry = { version = "0.31", default-features = false, features = ["backtrace", "contexts", "panic", "rustls", "reqwest"] }
 sentry-tracing = "0.31"
 tlmcmddb = "0.2.0"
-structpack = "0.5.0"
-gaia-ccsds-c2a = { path = "../gaia-ccsds-c2a" }
-gaia-tmtc = { path = "../gaia-tmtc" }
+structpack.workspace = true
+gaia-ccsds-c2a.workspace = true
+gaia-tmtc.workspace = true
 kble-socket = { version = "0.2.0", features = ["tungstenite"] }
 tokio-tungstenite = "0.18"
 itertools = "0.11.0"


### PR DESCRIPTION
- `structpack` の内部でのバージョン参照を 0.6 系に変更します（実態としての変更はなし）
- `structpack` など，Gaia 内部の crate の使用バージョンをまとめて管理するため，`workspace.dependencies` にまとめます