### PR TITLE
Add release automation workflow for binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    tags: ['v*']
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+
+      - name: install apt depenedencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Get Rust toolchain
+        id: toolchain
+        working-directory: .
+        run: |
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2.7.3
+
+      - name: install cargo-about
+        run: |
+          cargo install --locked cargo-about
+
+      - name: Build
+        run: |
+          cargo build --target=${{ matrix.target }} --release --locked
+
+      - name: Rename binaries
+        run: |
+          mkdir bin
+          gaia_bins=("tmtc-c2a")
+          for b in "${gaia_bins[@]}" ; do
+            cp "./target/${{ matrix.target }}/release/${b}" "./bin/${b}-${{ matrix.target }}"
+          done
+          ls -lh ./bin
+
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: release-executable-${{ matrix.target }}
+          if-no-files-found: error
+          path: ./bin/
+
+  release:
+    name: Release
+    needs: [ build ]
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/download-artifact@v4.1.3
+        with:
+          pattern: release-executable-*
+          merge-multiple: true
+
+      - run: |
+          chmod +x tmtc-c2a
+
+      - run: ls -lh
+
+      - name: Release to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+          files: |
+            tmtc-c2a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "c2a-devtools-frontend"
-version = "0.6.1"
+version = "0.7.0-beta.1"
 dependencies = [
  "rust-embed",
 ]
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-ccsds-c2a"
-version = "0.6.1"
+version = "0.7.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-stub"
-version = "0.6.1"
+version = "0.7.0-beta.1"
 dependencies = [
  "prost",
  "prost-types",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-tmtc"
-version = "0.6.1"
+version = "0.7.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "structpack"
-version = "0.6.1"
+version = "0.7.0-beta.1"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "tmtc-c2a"
-version = "0.6.1"
+version = "0.7.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0-beta.1"
 
 [workspace.dependencies]
 structpack = "0.6"

--- a/devtools-frontend/Cargo.toml
+++ b/devtools-frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2a-devtools-frontend"
 edition = "2021"
-version = "0.6.1"
+version = "0.7.0-beta.1"
 license = "MPL-2.0"
 
 [dependencies]


### PR DESCRIPTION
## 概要
#68 でライセンス表示をバイナリに埋め込んだので，バイナリ配布を行う．
サポートするプラットフォームは以下
- x86_64-unknown-linux-musl

kble での事例: https://github.com/arkedge/kble/pull/60

## 変更の意図や背景
現在 C2A user を中心に `tmtc-c2a` を利用している Gaia user が多い．
Gaia ではまだバイナリ配布をしていないため，各所で `cargo install` をするスクリプトを書いている．
例: https://github.com/arkedge/c2a-core/blob/v4.3.0/examples/mobc/tools/install.sh

しかし，Gaia は非常にたくさんのライブラリを用いているため，ビルドが非常に重い．
また，[C2A DevTools](https://github.com/arkedge/c2a-devtools) frontend のホスト（#33）や wasm による [opslang](https://github.com/arkedge/opslang) の導入（#54），[notalawyer](https://github.com/arkedge/notalawyer) の導入（#68）などによって，Gaia のビルドはより複雑かつビルドにあたって要求する環境も変化してきている．

このような重く複雑なビルドを各 C2A user を少し動かしてみるレベルのユーザに要求するのは非現実的であるため，[notalawyer](https://github.com/arkedge/notalawyer) でライセンス表示を行うことでバイナリ配布を実施する．

## 発端となる Issue
N/A (internal)