### PR TITLE
Install missing protc in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get Rust toolchain
         id: toolchain
         working-directory: .


### PR DESCRIPTION
## 概要
#97 で protoc を入れるのを忘れていたので，インストールします

## 変更の意図や背景
同上

## 発端となる Issue / PR
- #97 