### PR TITLE
Install missing wasm-pack in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           cargo install --locked cargo-about
 
+      - name: Install wasm-pack
+        run: |
+          cargo install --locked wasm-pack
+
       - name: Build
         run: |
           cargo build --target=${{ matrix.target }} --release --locked


### PR DESCRIPTION
## 概要
- #98 と同様
- #97 でインストールし忘れていた `wasm-pack` をインストールします

## 変更の意図や背景
N/A

## 発端となる Issue / PR
- #97 