### PR TITLE
Fix release binary suffix to wildcard for target triple

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           merge-multiple: true
 
       - run: |
-          chmod +x tmtc-c2a
+          chmod +x tmtc-c2a*
 
       - run: ls -lh
 
@@ -96,4 +96,4 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           files: |
-            tmtc-c2a
+            tmtc-c2a*


### PR DESCRIPTION
## 概要
#97 でビルド済みバイナリの処理にバグがあったので修正

## 変更の意図や背景
release workflow でビルドしているバイナリは suffix として target triple を付けているが，`chmod` や GitHub Releases へのファイル添付処理などでそれを加味するのを忘れていた

## 発端となる Issue
