### PR TITLE
Set crates metadata to publish them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "c2a-devtools-frontend"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "rust-embed",
 ]
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-ccsds-c2a"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-stub"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "prost",
  "prost-types",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-tmtc"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "structpack"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "tmtc-c2a"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 resolver = "2"
+
 members = [
     "gaia-stub",
     "structpack",
@@ -17,7 +18,9 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
+description = "A command and control system for C2A-based satellites"
+repository = "https://github.com/arkedge/gaia"
 
 [workspace.dependencies]
 structpack = "0.6"

--- a/devtools-frontend/Cargo.toml
+++ b/devtools-frontend/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "c2a-devtools-frontend"
 edition = "2021"
-version = "0.7.0-beta.1"
+version = "0.7.0-beta.2"
 license = "MPL-2.0"
+description = "C2A Devtools Frontend"
+repository = "https://github.com/arkedge/gaia"
 
 [dependencies]
 rust-embed = { version = "8.0.0", features = ["interpolate-folder-path", "debug-embed"] }

--- a/gaia-ccsds-c2a/Cargo.toml
+++ b/gaia-ccsds-c2a/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "gaia-ccsds-c2a"
 version.workspace = true
+description.workspace = true
+repository.workspace = true
 edition = "2021"
 license = "MPL-2.0"
 

--- a/gaia-stub/Cargo.toml
+++ b/gaia-stub/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "gaia-stub"
 version.workspace = true
+description.workspace = true
+repository.workspace = true
 edition = "2021"
 license = "MPL-2.0"
 

--- a/gaia-tmtc/Cargo.toml
+++ b/gaia-tmtc/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "gaia-tmtc"
 version.workspace = true
+description.workspace = true
+repository.workspace = true
 edition = "2021"
 license = "MPL-2.0"
 

--- a/tmtc-c2a/Cargo.toml
+++ b/tmtc-c2a/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "tmtc-c2a"
 version.workspace = true
+description.workspace = true
+repository.workspace = true
 edition = "2021"
 license = "MPL-2.0"
 


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
crates.io に publish するため、package.description や package.repository を設定します。

## 変更の意図や背景
cargo binstall で tmtc-c2a をインストール可能にするためには crates.io への publish が必要であり、crates.io への publish にはそれらのメタデータの設定が必要だからです。

