### PR TITLE
Fix deps in workspace

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# for local testing
+[patch.crates-io]
+gaia-stub = { path = "gaia-stub" }
+gaia-ccsds-c2a = { path = "gaia-ccsds-c2a" }
+gaia-tmtc = { path = "gaia-tmtc" }
+c2a-devtools-frontend = { path = "devtools-frontend" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "c2a-devtools-frontend"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 dependencies = [
  "rust-embed",
 ]
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-ccsds-c2a"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-stub"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 dependencies = [
  "prost",
  "prost-types",
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "gaia-tmtc"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "structpack"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "tmtc-c2a"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 description = "A command and control system for C2A-based satellites"
 repository = "https://github.com/arkedge/gaia"
 
 [workspace.dependencies]
 structpack = "0.6"
 
-gaia-stub = { path = "gaia-stub" }
-gaia-ccsds-c2a = { path = "gaia-ccsds-c2a" }
-gaia-tmtc = { path = "gaia-tmtc" }
-c2a-devtools-frontend = { path = "devtools-frontend" }
+gaia-stub = "0.7.0-beta.3"
+gaia-ccsds-c2a = "0.7.0-beta.3"
+gaia-tmtc = "0.7.0-beta.3"
+c2a-devtools-frontend = "0.7.0-beta.3"

--- a/devtools-frontend/Cargo.toml
+++ b/devtools-frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c2a-devtools-frontend"
 edition = "2021"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 license = "MPL-2.0"
 description = "C2A Devtools Frontend"
 repository = "https://github.com/arkedge/gaia"


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
crates.io への publish にあたり、workspace 内の crate への参照を path ではなく version による参照にします。

## 変更の意図や背景
path で参照していると crates.io に publish できないんじゃ。

