### PR TITLE
Add C2A DevTools frontend CI workflow

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -18,6 +18,8 @@ jobs:
           submodules: recursive
 
       - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 21
 
       - name: Get Rust toolchain
         id: toolchain

--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -1,0 +1,51 @@
+name: DevTools
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  devtools:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4.1.2
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@v4.0.2
+
+      - name: Get Rust toolchain
+        id: toolchain
+        run: |
+          awk -F'[ ="]+' '$1 == "channel" { print "toolchain=" $2 }' rust-toolchain >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.toolchain }}
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+
+      - name: install pnpm
+        working-directory: devtools-frontend
+        run: corepack enable
+
+      - name: install frontend dependencies
+        working-directory: devtools-frontend
+        run: pnpm install
+
+      - name: lint
+        working-directory: devtools-frontend
+        run: pnpm lint
+
+      - name: build
+        working-directory: devtools-frontend
+        run: pnpm build


### PR DESCRIPTION
## 概要
C2A DevTools フロントエンド用の CI を追加する

## 変更の意図や背景
- 既にある Rust CI でも内部的にフロントエンドのビルドは行われるが，ログ出力が見づらいので別途ログ出力をしたい
- `cargo build` 経由でのビルドとは別に，フロントエンドの開発時には `devtools-frontend` のソースディレクトリで `pnpm build` することになり，ビルド時の条件が異なるが，こちらも常にビルドできる必要があり，そのチェックをしたい
  - そして，#110 ではソースディレクトリ内でのビルドのみ壊れている
- ビルドだけではなく，prettier や eslint などフロントエンド特有の lint もかけたい

## 発端となる Issue
- #110 