### PR TITLE
Ignore copy target dir to handle cargo package

### DIFF
--- a/devtools-frontend/build.rs
+++ b/devtools-frontend/build.rs
@@ -55,6 +55,11 @@ fn copy_devtools_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result
             if entry.file_name().to_str() == Some("node_modules") {
                 continue;
             }
+            // In `cargo package`, each crate source files are copied to
+            // target/package/crate-<version> & threre are target dir
+            if entry.file_name().to_str() == Some("target") {
+                continue;
+            }
             copy_devtools_dir(entry.path(), dst.as_ref().join(entry.file_name()))?;
         } else {
             fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
`c2a-devtools-frontend` のビルドスクリプトでソースディレクトリを `$OUT_DIR` にコピーする際，`target` も無視するようにする

## 変更の意図や背景
`cargo package` においては，`cargo build` とビルド時のディレクトリの挙動が異なる．
具体的には，
- ビルド前に workspace の `target/package` 以下にクリーンなビルドをするためソースディレクトリがコピーされる
- この際それぞれの crate のディレクトリを workspace root とするビルドが行われる
  - この生成物は `target/package/<crate>-<version>/target` に入る
- ビルドスクリプトが走る前にビルドスクリプト自体のビルドが行われる
  - ここで `target/package/<crate>-<version>/target` ができる
- `build.rs` でソースディレクトリを `$OUT_DIR` にコピーする
  - この `$OUT_DIR` は `target/package/<crate>-<version>/target` 内
  - ここで，`target/package/<crate>-<version>/target` を再帰的にコピーしてしまう
- File name is too long エラーになる

となってしまう．

## 発端となる Issue
- #108 

## 補足
`cargo package` がソースディレクトリを最初にコピーする際，`Cargo.toml` が存在するディレクトリはコピーされない．
このルールは現状 `package.include` などを指定しても bypass できない（正確には `package.license-file` のみ bypass されるが，意図が異なり confusing すぎる上に単一ファイルがコピーできてもあまり意味がない）．

これにより，`devtools-frontend/crates/wasm-opslang` が `cargo package` の時のみビルド前にソースディレクトリが存在しない状態になってしまう．そのため，この PR をマージした後も `cargo package` は通るようにはならない．