### PR TITLE
Fix prettier ignore files

### DIFF
--- a/devtools-frontend/.prettierignore
+++ b/devtools-frontend/.prettierignore
@@ -3,3 +3,5 @@ pnpm-lock.yaml
 /node_modules/
 /deploy/
 /src/proto/
+/crates/*/target
+/crates/*/pkg

--- a/devtools-frontend/.prettierignore
+++ b/devtools-frontend/.prettierignore
@@ -1,3 +1,4 @@
+pnpm-lock.yaml
 /dist/
 /node_modules/
 /deploy/


### PR DESCRIPTION
## 概要
`pnpm-lock.yaml` と `devtools-frontend` 内の wasm 用の crate の生成ファイルを `.prettierignore` に入れる

## 変更の意図や背景
自動生成のファイル群はフォーマットすべきでない

## 発端となる Issue / PR
- #111 