### PR TITLE
Bye actionlint large runner

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,3 +1,0 @@
-self-hosted-runner:
-  labels:
-    - ubuntu-latest-32c


### PR DESCRIPTION
## 概要
actionlint の self-hosted-runner 用の設定を削除する

## 変更の意図や背景
actionlint では large runner を使う必要はまったくなく，さらにそもそも現在 large runner を使っていないため

## 発端となる Issue
N/A