### PR TITLE
Make wasm-opslang crate to workspace root for profile & cargo metadata in wasm-pack

### DIFF
--- a/devtools-frontend/crates/wasm-opslang/Cargo.toml
+++ b/devtools-frontend/crates/wasm-opslang/Cargo.toml
@@ -1,3 +1,7 @@
+# This manifest should be workspace root to set `[profile.release]` individually
+# Additionally, this source dir is copied to $OUT_DIR in `cargo build` & this crate should be workspace root for `cargo metadata` invoked from `wask-pack` in source dir (not in $OUT_DIR, dev phase)
+[workspace]
+
 [package]
 name = "wasm-opslang"
 version = "0.1.0"


### PR DESCRIPTION
## 概要
`devtools-frontend/crates/wasm-opslang` を workspace root にします

## 変更の意図や背景
`devtools-frontennd` を開発する際，`pnpm crates:wasm-opslang` によって `wasm-pack` が叩かれ，この内部でビルド前に `cargo metadata` が実行されます．
しかし，`gaia` ディレクトリは cargo workspace なのにも関わらず，`wasm-opslang` crate は workspace member でも，workspace root でもないため，`cargo metadata` が失敗します（#110）．

この問題は `cargo build` によって `devtools-frontend` crate をビルドする際には起きない（`devtools-frontend` crate のソースディレクトリ毎 `$OUT_DIR` にコピーされ，ここに cargo workspace は無いため）ですが，`devtools-frontend` の開発時には `pnpm build` できてほしいため，対応します．

また，wasm 向けの crate はバイナリサイズ削減のためなどに `[profile.release]` などの設定をしたくなりますが，これは workspace root でしか行えない設定です．そのため，いずれにしろこの manifest は workspace root とする必要があります．

## 発端となる Issue
- #110 