### PR TITLE
Add cargo workspace for devtools-frontend WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
 ]
 
 exclude = [
-    # 開発時はdevtools_frontend 内で直接wasm-pack buildするため
-    "devtools-frontend/crates/wasm-opslang",
+    # WASM 用の別の cargo workspace であるため
+    "devtools-frontend/crates",
     # ビルド時はdevtools_frontend/crates が OUT_DIR 以下にコピーされた後wasm-pack buildされるため
     "target",
 ]

--- a/devtools-frontend/crates/Cargo.toml
+++ b/devtools-frontend/crates/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+resolver = "2"
+
+members = [
+    "wasm-opslang",
+]
+
+# profile config should be set in workspace root
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/devtools-frontend/crates/wasm-opslang/Cargo.toml
+++ b/devtools-frontend/crates/wasm-opslang/Cargo.toml
@@ -27,7 +27,3 @@ regex = "1.10.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.42"
-
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"


### PR DESCRIPTION
## 概要
`devtools-frontend/crates` を cargo workspace にします

## 変更の意図や背景
WASM 向けの crate の管理は，以下の理由から Gaia 本体の cargo workspace とは別途管理すべきです．

- ビルドターゲットが異なる
  - Gaia 本体のビルドターゲットは x86_64 や aarch64 である一方で，このディレクトリ内の crate のビルドターゲットは確実に WASM です
  - 一般的なベストプラクティスとして，想定するビルドターゲットが大きく異なる crate は別の cargo workspace で管理すべきです
    - 具体的には，workspace root dir で `cargo build` するとどのターゲット向けに何をビルドすべきなのかが非常に非自明になる上に，想定と異なるターゲット向けにビルドされる可能性を考慮しなければならなくなり，不毛です
- WASM 向けのビルドにおいてはバイナリサイズを気にする必要があるため
  - `[profile.release]` などを設定したくなりますが，これは workspace root でないと効果を発揮しない設定です
  - #117 では `wasm-opslang` crate を workspace root にする提案をしましたが，実用上は個々の WASM 向け crate の profile を個別にチューニングするようなケースは無いものと思われるため，この PR ではよりシンプルに `devtools-frontend/crates` を cargo workspace としています
- `wasm-pack` が呼び出す `cargo metadata` のため
  - WASM 向け crate のビルドで用いられる `wasm-pack` 内では，`cargo metadata` が呼び出されます
  - `cargo metadata` では，対象となる crate は workspace root（workspace manifest || 1 package context）もしくは workspace member であることが想定されています
  - しかし，この判定において，少なくとも現在は cargo workspace context であり，同時に `workspace.meber` でないことによって workspace root（というか workspace でない単一 package）である場合を想定しておらず，エラーになります
  - そのため，明示的に workspace root ないし workspace member にする必要があります
  - #117 では 明示的に workspace root にする提案でしたが，この PR では workspace member としています

そのため，WASM 用 crate 群のための cargo workspace を用意するため，`devtools-frontend/Cargo.toml` を追加し，`wasm-opslang` crate をこの cargo workspace の member にします

## 発端となる Issue / PR
- #110 
- #117 
