### PR TITLE
Fix cache cargo subcommand install

### DIFF
--- a/.github/workflows/devtools.yml
+++ b/.github/workflows/devtools.yml
@@ -30,11 +30,11 @@ jobs:
         with:
           toolchain: ${{ steps.toolchain.outputs.toolchain }}
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
-
       - name: cache dependencies
         uses: Swatinem/rust-cache@v2.7.3
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
 
       - name: install pnpm
         working-directory: devtools-frontend

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,14 +39,14 @@ jobs:
           toolchain: ${{ steps.toolchain.outputs.toolchain }}
           components: clippy, rustfmt
 
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+
       - name: Install cargo-about
         run: cargo install cargo-about --locked
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
-
-      - name: cache dependencies
-        uses: Swatinem/rust-cache@v2.7.3
 
       - name: reviewdog / clippy
         uses: sksat/action-clippy@v0.7.1

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -37,14 +37,14 @@ jobs:
         with:
           toolchain: ${{ steps.toolchain.outputs.toolchain }}
 
+      - name: cache dependencies
+        uses: Swatinem/rust-cache@v2.7.3
+
       - name: Install cargo-about
         run: cargo install cargo-about --locked
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
-
-      - name: cache dependencies
-        uses: Swatinem/rust-cache@v2.7.3
 
       - run: rm -rf ./target/doc
 


### PR DESCRIPTION
## 概要
`cargo install` でインストールしている cargo subcommand がキャッシュされていないので修正します

## 変更の意図や背景
同上

## 発端となる Issue
N/A