### PR TITLE
Setup NodeJS 21 in Rust workflows for integrated frontend build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
+      # for devtools-frontend
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 21
+
       - name: install apt depenedencies
         run: |
           sudo apt-get update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           submodules: recursive
 
+      # for devtools-frontend
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 21
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           submodules: recursive
 
+      # for devtools-frontend
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 21
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:


### PR DESCRIPTION
## 概要
SSIA

## 変更の意図や背景
Rust 向けの workflow においても，`tmtc-c2a` の `cargo build` 内で `devtools-frontend` のビルドが行われるため，NodeJS のセットアップをしておく必要がある．
`setup-node` をせずともデフォルトで NodeJS 18 が使えるが，`devtools-frontend` では NodeJS 21 を期待しており，warning が出る．
この修正は `cargo clippy` や `cargo test`, `cargo doc` などを行う分にはそこまで必要ではないが，NodeJS のバージョン起因の問題があった際に調査を容易にするため，また，Release workflow においては，実際に配布するバイナリのビルドを行う workflow であるため，統一して想定されている NodeJS 21 のセットアップを行う．

## 発端となる Issue
N/A