### PR TITLE
Update opslang to 0.2.1

### DIFF
--- a/devtools-frontend/crates/wasm-opslang/Cargo.toml
+++ b/devtools-frontend/crates/wasm-opslang/Cargo.toml
@@ -13,8 +13,8 @@ default = ["console_error_panic_hook"]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "*", features = ["console"] }
-opslang-ast = "0.2.0"
-opslang-parser = "0.2.0"
+opslang-ast = "0.2.1"
+opslang-parser = "0.2.1"
 async-recursion = "*"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by


### PR DESCRIPTION
エラーメッセージ改善のためopslangのバージョンを上げる