### PR TITLE
Invoke wasm-pack in wasm crate build script to package wasm into $OUT_DIR

### DIFF
--- a/devtools-frontend/crates/wasm-opslang/Cargo.toml
+++ b/devtools-frontend/crates/wasm-opslang/Cargo.toml
@@ -3,6 +3,8 @@ name = "wasm-opslang"
 version = "0.1.0"
 edition = "2021"
 
+links = "wasm-opslang"
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/devtools-frontend/crates/wasm-opslang/build.rs
+++ b/devtools-frontend/crates/wasm-opslang/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+use std::{env, path::PathBuf};
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    if !target.contains("wasm32") {
+        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+
+        let status = Command::new("wasm-pack")
+            .arg("build")
+            .arg("--weak-refs")
+            .arg("--target")
+            .arg("web")
+            .arg("--release")
+            .arg("--out-dir")
+            .arg(out_dir)
+            .status()
+            .expect("failed to execute wasm-pack");
+        assert!(status.success(), "failed to wasm-pack build");
+    }
+}

--- a/devtools-frontend/crates/wasm-opslang/build.rs
+++ b/devtools-frontend/crates/wasm-opslang/build.rs
@@ -2,10 +2,14 @@ use std::process::Command;
 use std::{env, path::PathBuf};
 
 fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    println!("cargo:out_dir={}", out_dir);
+
     let target = env::var("TARGET").unwrap();
 
     if !target.contains("wasm32") {
-        let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+        let out_dir = PathBuf::from(out_dir);
 
         let status = Command::new("wasm-pack")
             .arg("build")


### PR DESCRIPTION
## 概要
`wasm-opslang` crate を `cargo build` したら内部で `wasm-pack build` するようにする

## 変更の意図や背景
- `wasm-pack` のビルド生成物を Cargo のパッケージ管理に載せるため
  - `devtools-frontend` のみを Cargo のパッケージ管理に載せていると、`cargo package` できなくなる（https://github.com/arkedge/gaia/pull/112 ）
- Cargo の build script はビルド前に走る処理しか記述できないので、`build.rs` 内に `wasm-pack` 相当の処理を載せることはできない（https://github.com/rustwasm/wasm-pack/issues/251 ）
  - そこで、wasm のビルドは確実にビルドターゲットが異なる（まだこの世には wasm32 のマシンは存在しないし、存在してもそこで Gaia をビルドしたい理由は現状存在しない）という性質に着目した
  - つまり、`$TARGET` が `wasm32` でないときに `build.rs` 内部で `wasm-pack` を呼び出してビルドする
  - 注意: wasm 向けの crate が x86_64 向けや aarch64 向けにも形の上ではビルドできる必要がある
    - これは現状の `wasm-opslang` では何も問題なくできる
    - 問題が発生したとしても、あくまで形の上でだけビルドできればよいので、`cfg` で対応可能
- `package.links` を用いて、dependents crate （の `build.rs`）に `$OUT_DIR` を渡す

## 発端となる Issue
- #108 