### PR TITLE
Fix devtools-frontend protobuf codegen path

### DIFF
--- a/devtools-frontend/package.json
+++ b/devtools-frontend/package.json
@@ -2,9 +2,9 @@
   "name": "c2a-devtools",
   "version": "0.0.0",
   "scripts": {
-    "codegen:proto:tco_tmiv": "protoc --ts_out src/proto --proto_path ../../gaia-stub/proto ../../gaia-stub/proto/tco_tmiv.proto",
-    "codegen:proto:broker": "protoc --ts_out src/proto --proto_path ../../gaia-stub/proto ../../gaia-stub/proto/broker.proto",
-    "codegen:proto:tmtc_generic_c2a": "protoc --ts_out src/proto --proto_path ../../tmtc-c2a/proto ../../tmtc-c2a/proto/tmtc_generic_c2a.proto",
+    "codegen:proto:tco_tmiv": "protoc --ts_out src/proto --proto_path ../gaia-stub/proto ../gaia-stub/proto/tco_tmiv.proto",
+    "codegen:proto:broker": "protoc --ts_out src/proto --proto_path ../gaia-stub/proto ../gaia-stub/proto/broker.proto",
+    "codegen:proto:tmtc_generic_c2a": "protoc --ts_out src/proto --proto_path ../tmtc-c2a/proto ../tmtc-c2a/proto/tmtc_generic_c2a.proto",
     "codegen:proto": "run-p codegen:proto:*",
     "codegen": "run-s codegen:proto",
     "crate:build": "cd crates && wasm-pack build --weak-refs --target web --release",


### PR DESCRIPTION
## 概要
SSIA

## 変更の意図や背景
- #74 で `devtools-frontend` のパスが変更されてから、Protobuf のコード生成のパスが誤ったものになっていたのを修正する

## 発端となる Issue / PR
- #74 