### PR TITLE
kble_gsをWebSocketのgracefulな終了に対応させる

### DIFF
--- a/tmtc-c2a/src/kble_gs.rs
+++ b/tmtc-c2a/src/kble_gs.rs
@@ -65,10 +65,14 @@ impl Socket {
                 }
                 anyhow::Ok(())
             };
-            let res: Result<((), ())> = future::try_join(uplink, downlink).await;
+            let res = tokio::select! {
+                res = uplink => res,
+                res = downlink => res,
+            };
             if let Err(e) = res {
                 error!("kble socket error: {e}")
             }
+            sink.close().await?;
         }
     }
 }


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
kble_gsのWebSocket接続がgracefulに終了した場合、uplink側はコマンド待ちで終了せず、downlink側はエラーを吐かないため、（次のコマンドが送られてきてsendに失敗するまで）joinから抜けられない
したがってjoinをselectに変更する

また、終了時に`sink.clone()`することでWebSocketの接続をgracefulに終了する

## 変更の意図や背景

## 発端となる Issue
