### PR TITLE
Fix opslang-wasm packaging

### DIFF
--- a/devtools-frontend/crates/opslang-wasm/build.rs
+++ b/devtools-frontend/crates/opslang-wasm/build.rs
@@ -1,26 +1,44 @@
+use std::fs;
 use std::process::Command;
 use std::{env, path::PathBuf};
 
 fn main() {
+    // no build logic on wasm32 build (cargo build called from wasm-pack)
+    let target = env::var("TARGET").unwrap();
+    if target.contains("wasm32") {
+        return;
+    }
+
+    // Just called cargo build (target may be x86_64 or aarch64)
+    // But, now we build wasm by wasm-pack
+
     let out_dir = env::var("OUT_DIR").unwrap();
 
+    // pass dist directory path to dependents crate (via package.links)
+    // it can be used as DEP_OPSLANG_WASM_OUT_DIR in dependents build.rs
     println!("cargo:out_dir={}", out_dir);
 
-    let target = env::var("TARGET").unwrap();
+    // Of course we think we should copy source dir into $OUT_DIR
+    //  & build(wasm-pack build) in $OUT_DIR,
+    //  we can't be happy with cargo-metadata called from wasm-pack build
+    //  (from cargo build only.not from cargo package)
+    let out_dir = PathBuf::from(out_dir);
 
-    if !target.contains("wasm32") {
-        let out_dir = PathBuf::from(out_dir);
+    // Let's go
+    let status = Command::new("wasm-pack")
+        .arg("build")
+        .arg("--weak-refs")
+        .arg("--target")
+        .arg("web")
+        .arg("--release")
+        .arg("--out-dir")
+        .arg(out_dir)
+        .status()
+        .expect("failed to execute wasm-pack");
+    assert!(status.success(), "failed to wasm-pack build");
 
-        let status = Command::new("wasm-pack")
-            .arg("build")
-            .arg("--weak-refs")
-            .arg("--target")
-            .arg("web")
-            .arg("--release")
-            .arg("--out-dir")
-            .arg(out_dir)
-            .status()
-            .expect("failed to execute wasm-pack");
-        assert!(status.success(), "failed to wasm-pack build");
-    }
+    // wasm-pack build (cargo build --target wasm32) generates Cargo.lock
+    // On cargo build, it's fine.
+    // On cargo package, it cause a catastrophe!!! (it can't be exists in source directory)
+    fs::remove_file("Cargo.lock").unwrap_or(());
 }


### PR DESCRIPTION
## 概要
`opslang-wasm` crate が `cargo package` できるようにする

## 変更の意図や背景
- #132 の時点だと、`opslang-wasm` crate で `cargo package` すると `Cargo.lock` が（`target/package` 中の）ソースディレクトリ中に発生してしまい、エラーになってしまう
- この問題の素朴な解決策としては `opslang-wasm` のソースディレクトリを（x86_64/aarch64 ビルドの）`$OUT_DIR` 内にコピーしてそのディレクトリ内で `wasm-pack build` することが考えられる
- しかし（！）`cargo package` の時は `Cargo.toml` の `version.workspace = true` などを解決済みの `Cargo.toml` がソースディレクトリ中に存在するが、通常の `cargo build` などの時についてはそうではない
  - そのため、`cargo build` の時は、`version.workspace = true` などが未解決のままの（workspace member であるはずの）ソースディレクトリ一式が `$OUT_DIR` に単独でコピーされ、ビルドに使われる
  - このビルドは workspace root のものとして走るので、`version.workspace = true` などを解決できずビルドに失敗してしまう
- そこで（！！！）`wasm-pack build` の後、発生してしまったソースディレクトリ中の `Cargo.lock` を `build.rs` 中で削除することにした
- ついでに `wasm-opslang` のビルドロジックについてコメントを追加

## 発端となる Issue
- #108 