### PR TITLE
Merge crate license to cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude = [
 version = "0.7.0-beta.5"
 description = "A command and control system for C2A-based satellites"
 repository = "https://github.com/arkedge/gaia"
+license = "MPL-2.0"
 
 [workspace.dependencies]
 structpack = "0.6"

--- a/devtools-frontend/Cargo.toml
+++ b/devtools-frontend/Cargo.toml
@@ -3,8 +3,8 @@ name = "c2a-devtools-frontend"
 version.workspace = true
 description.workspace = true
 repository.workspace = true
+license.workspace = true
 edition = "2021"
-license = "MPL-2.0"
 
 [dependencies]
 rust-embed = { version = "8.0.0", features = ["interpolate-folder-path", "debug-embed"] }

--- a/devtools-frontend/crates/Cargo.toml
+++ b/devtools-frontend/crates/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 version = "0.7.0-beta.5"
 description = "A command and control system for C2A-based satellites"
 repository = "https://github.com/arkedge/gaia"
+license = "MPL-2.0"
 
 # profile config should be set in workspace root
 [profile.release]

--- a/devtools-frontend/crates/opslang-wasm/Cargo.toml
+++ b/devtools-frontend/crates/opslang-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "opslang-wasm"
 version.workspace = true
 description.workspace = true
 repository.workspace = true
+license.workspace = true
 edition = "2021"
 
 links = "opslang-wasm"

--- a/gaia-stub/Cargo.toml
+++ b/gaia-stub/Cargo.toml
@@ -3,8 +3,8 @@ name = "gaia-stub"
 version.workspace = true
 description.workspace = true
 repository.workspace = true
+license.workspace = true
 edition = "2021"
-license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/gaia-tmtc/Cargo.toml
+++ b/gaia-tmtc/Cargo.toml
@@ -3,8 +3,8 @@ name = "gaia-tmtc"
 version.workspace = true
 description.workspace = true
 repository.workspace = true
+license.workspace = true
 edition = "2021"
-license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/structpack/Cargo.toml
+++ b/structpack/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "structpack"
 version.workspace = true
+license.workspace = true
 edition = "2021"
-license = "MPL-2.0"
 description = "Dynamic bit-field accessor"
 documentation = "https://docs.rs/structpack"
 repository = "https://github.com/arkedge/gaia"

--- a/tmtc-c2a/Cargo.toml
+++ b/tmtc-c2a/Cargo.toml
@@ -3,8 +3,8 @@ name = "tmtc-c2a"
 version.workspace = true
 description.workspace = true
 repository.workspace = true
+license.workspace = true
 edition = "2021"
-license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## 概要
crate のライセンス定義を cargo workspace を使ってまとめる

## 変更の意図や背景
基本的に MPL-2.0 で統一しており、いちいち書くのは面倒なため。
今後このリポジトリ内で別のライセンスを付ける crate があった場合においても、その crate についてのみ別個に記述すればよいだけなので問題はない。

## 発端となる Issue / PR
- #132 のリリースのため