### PR TITLE
Specify async-recursion version explicitly

### DIFF
--- a/devtools-frontend/crates/opslang-wasm/Cargo.toml
+++ b/devtools-frontend/crates/opslang-wasm/Cargo.toml
@@ -20,7 +20,7 @@ wasm-bindgen-futures = "0.4"
 web-sys = { version = "*", features = ["console"] }
 opslang-ast = "0.2.1"
 opslang-parser = "0.2.1"
-async-recursion = "*"
+async-recursion = "1.1.0"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
## 概要
バージョン指定が `*` になっている dependency があったので修正します。

## 変更の意図や背景
`*` 指定だと cargo publish できないため。

## 発端となる Issue
https://github.com/arkedge/gaia/issues/108