### PR TITLE
[CI] cargo clippy & test with --locked

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,7 @@ jobs:
         uses: sksat/action-clippy@v0.7.1
         with:
           reporter: github-pr-review
+          clippy_flags: --locked
 
       - name: format
         run: |
@@ -64,4 +65,4 @@ jobs:
 
       - name: unit test
         run: |
-          cargo test
+          cargo test --locked


### PR DESCRIPTION
## 概要
Rust CI の `cargo clippy` および `cargo test` を `--locked` オプション付きでチェックする

## 変更の意図や背景
`--locked` でないと検知できない `Cargo.lock` を更新すべきタイミングなどがあるため

## 発端となる Issue / PR
- #140 のマージ後に `Cargo.lock` の未更新エラーが出た