### PR TITLE
Maintain package group in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,8 @@
       "packageNames": ["sentry", "sentry-tracing"]
     },
     {
-      "groupName": "tonic",
-      "groupSlug": "tonic",
+      "groupName": "http-grpc",
+      "groupSlug": "http-grpc",
       "packageNames": [
         "tonic",
         "tonic-build",
@@ -27,7 +27,22 @@
         "tonic-web",
         "prost",
         "prost-types",
-        "prost-derive"
+        "prost-derive",
+        "http",
+        "axum",
+        "tokio-tungstenite",
+        "kble-socket",
+        "tower",
+        "tower-http"
+      ]
+    },
+    {
+      "groupName": "protobuf-ts",
+      "groupSlug": "protobuf-ts",
+      "packageNames": [
+        "@protobuf-ts/runtime-rpc",
+        "@protobuf-ts/runtime",
+        "@protobuf-ts/grpcweb-transport"
       ]
     }
   ]


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
関連するパッケージの renovate PR がまとまるように、package group を調整します。

## 変更の意図や背景
npm の `protobuf-ts/*` シリーズや、Rust の HTTP や gRPC 関連の crate の更新がバラバラの PR になり単体では成立しない Pull Request になってしまいがちだったため。
