### PR TITLE
Tweak renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,8 @@
         "tokio-tungstenite",
         "kble-socket",
         "tower",
-        "tower-http"
+        "tower-http",
+        "http"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,12 @@
       ]
     },
     {
+      "groupName": "axum",
+      "groupSlug": "axum",
+      "matchPackageNames": ["axum"],
+      "allowedVersions": ["0.6.20"]
+    },
+    {
       "groupName": "protobuf-ts",
       "groupSlug": "protobuf-ts",
       "packageNames": [


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
renovate.json の設定を調整します。

## 変更の意図や背景
`http` crate が `http-grpc` から漏れていたので追加します。
最新の `axum` v0.7 系は、他の多くの crate と非互換な依存関係を持っているので、当面の間 v0.6 系の最後のバージョンである v0.6.20 に固定します。
