### PR TITLE
Pin tokio-tungstenite to compatible version with tonic 0.11

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,12 @@
       "allowedVersions": ["0.6.20"]
     },
     {
+      "groupName": "tungstenite",
+      "groupSlug": "tungstenite",
+      "matchPackageNames": ["tokio-tungstenite"],
+      "allowedVersions": ["0.20.1"]
+    }
+    {
       "groupName": "protobuf-ts",
       "groupSlug": "protobuf-ts",
       "packageNames": [


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
tokio-tungstenite を tonic v0.11 と互換性のあるバージョンに固定します。

## 変更の意図や背景
https://github.com/hyperium/tonic/issues/1579 という事情があり、tonic は hyper 1.0 や axum 0.7 系の世界に追従するのに苦戦している。
当面は hyper 0.14 や axum 0.6 系でやっていく。

## 発端となる Issue
関連: https://github.com/arkedge/gaia/pull/164
通らなくて困っているビルドがある PR: https://github.com/arkedge/gaia/pull/159