### PR TITLE
Pin http to version compatible with tonic 0.11

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,12 @@
       "allowedVersions": ["0.20.1"]
     },
     {
+      "groupName": "http",
+      "groupSlug": "http",
+      "matchPackageNames": ["http"],
+      "allowedVersions": ["0.2.11"]
+    },
+    {
       "groupName": "protobuf-ts",
       "groupSlug": "protobuf-ts",
       "packageNames": [


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
http crate のバージョンを tonic 0.11 と互換性のあるバージョンに固定します。

## 発端となる Issue
#164 #167 と同様の変更