### PR TITLE
Suppress warns

### DIFF
--- a/devtools-frontend/crates/opslang-wasm/src/lib.rs
+++ b/devtools-frontend/crates/opslang-wasm/src/lib.rs
@@ -17,6 +17,7 @@ pub fn set_panic_hook() {
 type Result<T, E = RuntimeError> = std::result::Result<T, E>;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 enum RuntimeError {
     ParseIntError(std::num::ParseIntError),
     ParseFloatError(std::num::ParseFloatError),


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
warnings をひとまず無視します。

## 変更の意図や背景
opslang-wasm において、RuntimeError のいくつかの variant に unused field があるという warn が出ていた。
これらは見かけ上 unused であるが、Debug 用に必要なので残すべきものだと判断し、`allow(dead_code)` とした。

```
warning: field `0` is never read
  --> devtools-frontend/crates/opslang-wasm/src/lib.rs:21:19
   |
21 |     ParseIntError(std::num::ParseIntError),
   |     ------------- ^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     field in this variant
```

@kobkaz この修正でいいですかね？　もしベターな修正案などあればお願いします。