### PR TITLE
make devtools/binary dependency optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: install cargo-about
         run: |
-          cargo install --locked cargo-about
+          cargo install --locked cargo-about@0.6.4
 
       - name: Install wasm-pack
         run: |
@@ -105,7 +105,7 @@ jobs:
 
       - name: install cargo-about
         run: |
-          cargo install --locked cargo-about
+          cargo install --locked cargo-about@0.6.4
 
       - name: Install wasm-pack
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.5
 
       - name: Install cargo-about
-        run: cargo install cargo-about --locked
+        run: cargo install cargo-about@0.6.4 --locked
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -46,7 +46,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.5
 
       - name: Install cargo-about
-        run: cargo install cargo-about --locked
+        run: cargo install cargo-about@0.6.4 --locked
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked

--- a/tmtc-c2a/Cargo.toml
+++ b/tmtc-c2a/Cargo.toml
@@ -37,7 +37,7 @@ tlmcmddb = "2.5.1"
 structpack.workspace = true
 gaia-ccsds-c2a.workspace = true
 gaia-tmtc.workspace = true
-c2a-devtools-frontend.workspace = true
+c2a-devtools-frontend = { workspace = true, optional = true }
 kble-socket = { version = "0.3.0", features = ["tungstenite"] }
 tokio-tungstenite = "0.20.1"
 itertools = "0.12.1"
@@ -46,4 +46,9 @@ notalawyer-clap = "0.1.0"
 
 [build-dependencies]
 tonic-build = "0.11"
-notalawyer-build = "0.1.0"
+notalawyer-build = { version = "0.1.0", optional = true }
+
+[features]
+default = ["bin", "devtools"]
+bin = ["dep:notalawyer-build"]
+devtools = ["dep:c2a-devtools-frontend"]

--- a/tmtc-c2a/build.rs
+++ b/tmtc-c2a/build.rs
@@ -8,5 +8,6 @@ fn main() {
         .compile(&["./proto/tmtc_generic_c2a.proto"], &["./proto"])
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
 
+    #[cfg(feature = "bin")]
     notalawyer_build::build();
 }

--- a/tmtc-c2a/src/lib.rs
+++ b/tmtc-c2a/src/lib.rs
@@ -7,4 +7,5 @@ pub mod satellite;
 mod tco;
 mod tmiv;
 
+#[cfg(feature = "devtools")]
 pub mod devtools_server;


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
tmtc-c2aをライブラリとして使いたいが、wasm-packやcargo-aboutがないとビルドできないのは不便なので、これらへの依存なしでビルドできるようにする

## 変更の意図や背景

## 発端となる Issue
