### PR TITLE
Pin tlmcmddb to v2.5.1 because v2.6.1 brakes compatibility

### DIFF
--- a/gaia-ccsds-c2a/Cargo.toml
+++ b/gaia-ccsds-c2a/Cargo.toml
@@ -16,6 +16,6 @@ funty = "2"
 modular-bitfield-msb = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 zerocopy = "0.6"
-tlmcmddb = "2.5.1"
+tlmcmddb = "=2.5.1"
 structpack.workspace = true
 async-trait = "0.1"


### PR DESCRIPTION
ref: https://github.com/arkedge/c2a-tlmcmddb/issues/112