### PR TITLE
devtools: improve error message

### DIFF
--- a/devtools-frontend/src/components/OldCommandView.tsx
+++ b/devtools-frontend/src/components/OldCommandView.tsx
@@ -115,9 +115,14 @@ const buildTco = (
     commandLine.parameters.length !==
     commandSchema.parameters.length + extraParams
   ) {
-    throw new Error(
-      `the number of parameters is wrong: expected ${commandSchema.parameters.length}, but got ${commandLine.parameters.length}`,
-    );
+    let explain = "";
+    if (extraParams == 0) {
+      explain = `expected ${commandSchema.parameters.length} parameters, but got ${commandLine.parameters.length}`;
+    } else {
+      explain = `${commandSchema.parameters.length} normal parameters and ${extraParams} ti parameters, but got ${commandLine.parameters.length} in total`;
+    }
+
+    throw new Error(`the number of parameters is wrong: ${explain}`);
   }
   const tcoParams: TcoParam[] = [];
   if (commandSubsystem.hasTimeIndicator) {


### PR DESCRIPTION
<!-- 非公開リポジトリのリンクを貼ってはならない -->
## 概要
わかりにくいエラーメッセージを修正

## 変更の意図や背景
tiが絡んだときに

> Error: the number of parameters is wrong: expected 2, but got 2

のようなエラーメッセージが出ていた
## 発端となる Issue
