### PR TITLE
change renovate option to disable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "matchDepTypes": [
         "devDependencies"
       ],
-      "automerge": true
+      "automerge": false
     },
     {
       "groupName": "Sentry",


### PR DESCRIPTION
# 概要

npmのサプライチェーンアタックに対応して全てのnpmに依存しているrepositoryのautomergeを停止します